### PR TITLE
Fix broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Griffin R. – Huge help on reading game memory.
 
 [The Pokémon ROM hacking/decompilation community](https://pret.github.io) – Without them, this wouldn’t have been possible.
 
-[OpenPipe](openpipe.ai/) - LLM observability.
+[OpenPipe](https://openpipe.ai/) - LLM observability.
 
 Contact
 
-You can find me on [LinkedIn](linkedin.com/in/adenta/) and [Hacker News](https://news.ycombinator.com/user?id=adenta).
+You can find me on [LinkedIn](https://linkedin.com/in/adenta/) and [Hacker News](https://news.ycombinator.com/user?id=adenta).


### PR DESCRIPTION
Lack of https:// in the README causes the links to lead back to 404's on github.com. This commit adds https:// to fix it.